### PR TITLE
Install Go in Phase 1 + verify gogcli build in Phase 8

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -100,6 +100,24 @@ if ! command -v jq &>/dev/null; then
     pkg_install jq
 fi
 
+# ── Go (required for building gogcli in Phase 8) ───────────────────
+if ! command -v go &>/dev/null; then
+    log "Installing Go (needed to build gogcli for Gmail sync)..."
+    if [ "$PLATFORM" = "macos" ]; then
+        brew install go
+    elif [ "$DISTRO" = "debian" ]; then
+        sudo apt-get install -y golang-go
+    elif [ "$DISTRO" = "fedora" ]; then
+        sudo dnf install -y golang
+    elif [ "$DISTRO" = "arch" ]; then
+        sudo pacman -S --noconfirm go
+    else
+        warn "Install Go manually: https://go.dev/doc/install"
+    fi
+else
+    log "Go $(go version 2>/dev/null | awk '{print $3}') already installed"
+fi
+
 # ── Google Cloud SDK ────────────────────────────────────────────────
 if ! command -v gcloud &>/dev/null; then
     log "Installing Google Cloud SDK..."

--- a/scripts/setup_email.sh
+++ b/scripts/setup_email.sh
@@ -29,6 +29,8 @@ if [ "$EMAIL_PROVIDER" = "google" ]; then
     if ! command -v gog &>/dev/null; then
         echo "Installing gogcli..."
         TMPDIR=$(mktemp -d)
+        # gogcli is a Go program, so we need both `make` (drives the build)
+        # and `go` (does the actual compile). Check both before attempting.
         if ! command -v make &>/dev/null; then
             err "Cannot build gogcli: 'make' not found."
             if [ "$PLATFORM" = "macos" ]; then
@@ -36,6 +38,21 @@ if [ "$EMAIL_PROVIDER" = "google" ]; then
             else
                 err "  Install build tools: sudo apt-get install build-essential (Debian) or sudo dnf install make gcc (Fedora)"
             fi
+            warn "Skipping gogcli installation."
+        elif ! command -v go &>/dev/null; then
+            err "Cannot build gogcli: 'go' not found."
+            if [ "$PLATFORM" = "macos" ]; then
+                err "  Install Go: brew install go"
+            elif [ "$DISTRO" = "debian" ]; then
+                err "  Install Go: sudo apt-get install golang-go"
+            elif [ "$DISTRO" = "fedora" ]; then
+                err "  Install Go: sudo dnf install golang"
+            elif [ "$DISTRO" = "arch" ]; then
+                err "  Install Go: sudo pacman -S go"
+            else
+                err "  Install Go: https://go.dev/doc/install"
+            fi
+            err "  Then re-run: ./setup.sh --from 8"
             warn "Skipping gogcli installation."
         else
             (
@@ -46,13 +63,26 @@ if [ "$EMAIL_PROVIDER" = "google" ]; then
                 mkdir -p ~/.local/bin
                 cp gog ~/.local/bin/
             )
+            BUILD_STATUS=$?
             rm -rf "$TMPDIR"
 
-            if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
-                echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
-                export PATH="$HOME/.local/bin:$PATH"
+            # Don't trust the subshell — verify the binary actually landed.
+            # Phase 8 used to log "installed" unconditionally, then transcript
+            # sync would blow up much later with FileNotFoundError on `gog`.
+            if [ $BUILD_STATUS -ne 0 ] || [ ! -x "$HOME/.local/bin/gog" ]; then
+                err "gogcli build failed — '$HOME/.local/bin/gog' not present after build."
+                err "  Try manually:"
+                err "    cd /tmp && git clone https://github.com/steipete/gogcli.git"
+                err "    cd gogcli && make && cp gog ~/.local/bin/"
+                err "  Then re-run: ./setup.sh --from 8"
+                warn "Skipping gogcli configuration — Gmail transcript sync will be unavailable."
+            else
+                if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+                    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
+                    export PATH="$HOME/.local/bin:$PATH"
+                fi
+                log "gogcli installed to ~/.local/bin/gog"
             fi
-            log "gogcli installed to ~/.local/bin/gog"
         fi
     else
         log "gogcli already installed"

--- a/sync-scripts/sync_meeting_transcripts.py
+++ b/sync-scripts/sync_meeting_transcripts.py
@@ -528,9 +528,19 @@ def save_state(state: dict):
 # ── Main ────────────────────────────────────────────────────────────────────
 
 def main():
-    if EMAIL_PROVIDER == "google" and not ACCOUNT:
-        print("ERROR: Set GOG_ACCOUNT environment variable (email_provider is 'google').", file=sys.stderr)
-        sys.exit(1)
+    if EMAIL_PROVIDER == "google":
+        if not GOG.exists():
+            print(f"ERROR: gogcli not installed at {GOG}", file=sys.stderr)
+            print("  Phase 8 of setup.sh installs it; if that was skipped or failed,", file=sys.stderr)
+            print("  install Go and re-run: ./setup.sh --from 8", file=sys.stderr)
+            print("  Or manually: brew install go && cd /tmp && \\", file=sys.stderr)
+            print("    git clone https://github.com/steipete/gogcli.git && \\", file=sys.stderr)
+            print("    cd gogcli && make && cp gog ~/.local/bin/", file=sys.stderr)
+            sys.exit(1)
+        if not ACCOUNT:
+            print("ERROR: GOG_ACCOUNT not set (email_provider is 'google').", file=sys.stderr)
+            print("  Re-run setup phase 8 to authenticate gogcli, or set GOG_ACCOUNT manually.", file=sys.stderr)
+            sys.exit(1)
 
     full_mode = "--full" in sys.argv
     skip_actions = "--skip-actions" in sys.argv


### PR DESCRIPTION
## Summary
- `install_deps.sh` now installs Go on macOS (`brew install go`) and Linux (`apt`/`dnf`/`pacman`). gogcli is a Go program; without Go installed the `make` target in Phase 8 fails.
- `setup_email.sh` adds a preflight `go` check (matching the existing `make` check) and verifies `~/.local/bin/gog` actually exists after the build subshell. Previously it logged "gogcli installed" unconditionally and the failure only surfaced in Phase 11 as a `FileNotFoundError` traceback.
- `sync_meeting_transcripts.py` adds a friendly preflight error if `gog` is missing instead of crashing with a raw subprocess traceback.

## Why
Caught on a fresh macOS Python.org install (Ravi). Phase 8 reported success, then Phase 11 transcript sync blew up with:
```
FileNotFoundError: [Errno 2] No such file or directory: '/Users/.../local/bin/gog'
```
Root cause: Xcode CLI tools give you `make`, but Go is a separate dep that nothing was installing.

## Test plan
- [ ] Re-run `./setup.sh --from 1` on Ravi's Mac (or `--from 8` if Phase 1 already ran cleanly)
- [ ] Confirm Go gets installed via brew
- [ ] Confirm `~/.local/bin/gog --version` works after Phase 8
- [ ] Confirm Phase 11 transcript sync no longer errors
- [ ] On a Linux box, confirm `apt-get install golang-go` path also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)